### PR TITLE
Add end time to visible cues list

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,6 +15,7 @@ module.exports = function readString(vtt) {
       return {
         id: idx,
         start: cue.start,
+        end: cue.end,
         text: cue.rest.join('\n')
       };
     });


### PR DESCRIPTION
This makes it possible for the user to read the end time of a cue. It adds the `end` property which is available from the read VTT data to the `cues` property which is exposed to the user. 